### PR TITLE
Add 'y' option to AxisAnchor

### DIFF
--- a/core/shared/src/main/scala/plotly/element/AxisAnchor.scala
+++ b/core/shared/src/main/scala/plotly/element/AxisAnchor.scala
@@ -6,4 +6,5 @@ sealed abstract class AxisAnchor(val label: String) extends Product with Seriali
 object AxisAnchor {
   case class Reference(axisReference: AxisReference) extends AxisAnchor(axisReference.label)
   case object Free extends AxisAnchor("free")
+  case object Y extends AxisAnchor("y")
 }


### PR DESCRIPTION
The `AxisAnchor` overlaying option in `Axis` ([here](https://github.com/alexblickenstaff/plotly-scala/blob/master/core/shared/src/main/scala/plotly/layout/Axis.scala#L35)) needs a `'y'` option (as shown [in the plotly docs](https://plot.ly/python/multiple-axes/)).