### PR TITLE
Add jQuery cdn url to fix rendering in nbviewer

### DIFF
--- a/almond/src/main/scala/plotly/Almond.scala
+++ b/almond/src/main/scala/plotly/Almond.scala
@@ -28,7 +28,8 @@ object Almond {
         """require.config({
           |  paths: {
           |    d3: 'https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min',
-          |    plotly: 'https://cdn.plot.ly/plotly-1.12.0.min'
+          |    plotly: 'https://cdn.plot.ly/plotly-1.12.0.min',
+          |    jquery: 'https://code.jquery.com/jquery-3.3.1.min'
           |  },
           |
           |  shim: {


### PR DESCRIPTION
Yet another small JS fix.

Without defining a url for jQuery, rendering plotly charts doesn't work in [nbviewer](https://nbviewer.jupyter.org/), because requirejs tries to load jQuery locally and fails.

You can see this in action here (check the browser console to see the errors):
https://nbviewer.jupyter.org/github/sbrunk/almond-examples/blob/master/plotly_examples.ipynb

In contrast the notebook using the fixed version nicely renders our charts:
https://nbviewer.jupyter.org/github/sbrunk/almond-examples/blob/jquery-fix/plotly_examples.ipynb