### PR TITLE
Cross build with Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ stages:
 jobs:
   include:
     - scala: 2.12.10
+    - scala: 2.13.1
     - stage: release
       script: ./sbt ci-release

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -88,16 +88,11 @@ object Settings {
   )
 
   private val scala212 = "2.12.10"
+  private val scala213 = "2.13.1"
 
   lazy val shared = Seq(
-    crossScalaVersions := Seq(scala212),
-    scalaVersion := scala212,
-    scalacOptions ++= {
-      if (scalaBinaryVersion.value == "2.12")
-        Seq()
-      else
-        Seq("-target:jvm-1.7")
-    },
+    crossScalaVersions := Seq(scala213, scala212),
+    scalaVersion := scala213,
     resolvers ++= Seq(
       "Webjars Bintray" at "https://dl.bintray.com/webjars/maven/",
       Resolver.sonatypeRepo("releases"),

--- a/tests/src/test/java/plotly/doc/NativeArrayWithDefault.java
+++ b/tests/src/test/java/plotly/doc/NativeArrayWithDefault.java
@@ -1,0 +1,19 @@
+package plotly.doc;
+
+import org.mozilla.javascript.NativeArray;
+
+// This class is to override NativeArray#getDefaultValue. Ideally we would just do this in an anonymous class in Scala
+// code, but https://github.com/scala/bug/issues/11575 makes this impossible.
+class NativeArrayWithDefault extends NativeArray {
+    private final Object defaultValue;
+
+    public NativeArrayWithDefault(Object[] array, Object defaultValue) {
+        super(array);
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public Object getDefaultValue(Class<?> hint) {
+        return defaultValue;
+    }
+}

--- a/tests/src/test/scala/plotly/doc/DocumentationTests.scala
+++ b/tests/src/test/scala/plotly/doc/DocumentationTests.scala
@@ -113,10 +113,7 @@ object DocumentationTests {
   private object Numeric {
     def linspace(from: Int, to: Int, count: Int) = {
       val step = (to - from).toDouble / (count - 1)
-      new NativeArray((0 until count).map(n => from + n * step: JDouble).toArray[AnyRef]) {
-        override def getDefaultValue(hint: Class[_]) =
-          0.0: JDouble
-      }
+      new NativeArrayWithDefault((0 until count).map(n => from + n * step: JDouble).toArray[AnyRef], 0.0: JDouble)
     }
   }
 


### PR DESCRIPTION
This PR adds support for Scala 2.13 and fixes #120.

The only tricky issue I found was with extending `NativeArray` in order to override `getDefaultValue`. I _believe_ that the issue described in https://github.com/scala/bug/issues/11575 is making it impossible to override `NativeArray` anonymously in Scala code. My solution was to create a new implementation in `NativeArrayWithDefault.java`. This feels excessive but was the best I could do. I'm open to feedback if there's a cleaner solution to the problem.

Hopefully this PR is useful. Let me know if there's any other changes required!