### PR TITLE
Use data-class everywhere

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ inThisBuild(List(
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .settings(
     shared,
-    plotlyPrefix
+    plotlyPrefix,
+    libraryDependencies += Deps.dataClass
   )
 
 lazy val coreJvm = core.jvm

--- a/core/shared/src/main/scala/plotly/Trace.scala
+++ b/core/shared/src/main/scala/plotly/Trace.scala
@@ -4,11 +4,12 @@ import scala.language.implicitConversions
 
 import java.lang.{ Boolean => JBoolean, Double => JDouble }
 
+import dataclass.data
 import plotly.element._
 
 sealed abstract class Trace extends Product with Serializable
 
-final case class Scatter(
+@data class Scatter(
              x: Option[Sequence],
              y: Option[Sequence],
           text: Option[OneOrSeq[String]],
@@ -88,7 +89,7 @@ object Scatter {
   }
 }
 
-case class Box(
+@data class Box(
              y: Option[Sequence],
              x: Option[Sequence],
      boxpoints: Option[BoxPoints],
@@ -137,7 +138,7 @@ object Box {
     )
 }
 
-final case class Bar(
+@data class Bar(
              x: Sequence,
              y: Sequence,
           name: Option[String],
@@ -192,7 +193,7 @@ object Bar {
     )
 }
 
-case class Histogram(
+@data class Histogram(
           x: Option[Sequence],
           y: Option[Sequence],
     opacity: Option[Double],

--- a/core/shared/src/main/scala/plotly/element/AxisAnchor.scala
+++ b/core/shared/src/main/scala/plotly/element/AxisAnchor.scala
@@ -1,10 +1,12 @@
 package plotly
 package element
 
+import dataclass.data
+
 sealed abstract class AxisAnchor(val label: String) extends Product with Serializable
 
 object AxisAnchor {
-  case class Reference(axisReference: AxisReference) extends AxisAnchor(axisReference.label)
+  @data class Reference(axisReference: AxisReference) extends AxisAnchor(axisReference.label)
   case object Free extends AxisAnchor("free")
   case object Y extends AxisAnchor("y")
 }

--- a/core/shared/src/main/scala/plotly/element/Bins.scala
+++ b/core/shared/src/main/scala/plotly/element/Bins.scala
@@ -1,3 +1,9 @@
 package plotly.element
 
-case class Bins(start: Double, end: Double, size: Double)
+import dataclass.data
+
+@data class Bins(
+  start: Double,
+  end: Double,
+  size: Double
+)

--- a/core/shared/src/main/scala/plotly/element/BoxMean.scala
+++ b/core/shared/src/main/scala/plotly/element/BoxMean.scala
@@ -1,10 +1,12 @@
 package plotly
 package element
 
+import dataclass.data
+
 sealed abstract class BoxMean extends Product with Serializable
 
 object BoxMean {
-  case class Bool(value: Boolean) extends BoxMean
+  @data class Bool(value: Boolean) extends BoxMean
   sealed abstract class Labeled(val label: String) extends BoxMean
 
   val True = Bool(true)

--- a/core/shared/src/main/scala/plotly/element/BoxPoints.scala
+++ b/core/shared/src/main/scala/plotly/element/BoxPoints.scala
@@ -1,10 +1,12 @@
 package plotly
 package element
 
+import dataclass.data
+
 sealed abstract class BoxPoints extends Product with Serializable
 
 object BoxPoints {
-  case class Bool(value: Boolean) extends BoxPoints
+  @data class Bool(value: Boolean) extends BoxPoints
   sealed abstract class Labeled(val label: String) extends BoxPoints
 
   val False = Bool(false)

--- a/core/shared/src/main/scala/plotly/element/Color.scala
+++ b/core/shared/src/main/scala/plotly/element/Color.scala
@@ -1,13 +1,15 @@
 package plotly
 package element
 
+import dataclass.data
+
 sealed abstract class Color extends Product with Serializable
 
 object Color {
 
-  final case class RGBA(r: Int, g: Int, b: Int, alpha: Double) extends Color
+  @data class RGBA(r: Int, g: Int, b: Int, alpha: Double) extends Color
 
-  final case class StringColor(color: String) extends Color
+  @data class StringColor(color: String) extends Color
 
   object StringColor {
     val colors = Set(
@@ -23,7 +25,7 @@ object Color {
     )
   }
 
-  final case class RGB(r: Int, g: Int, b: Int) extends Color
+  @data class RGB(r: Int, g: Int, b: Int) extends Color
 
-  final case class HSL(h: Int, s: Int, l: Int) extends Color
+  @data class HSL(h: Int, s: Int, l: Int) extends Color
 }

--- a/core/shared/src/main/scala/plotly/element/Cumulative.scala
+++ b/core/shared/src/main/scala/plotly/element/Cumulative.scala
@@ -1,3 +1,5 @@
 package plotly.element
 
-final case class Cumulative(enabled: Boolean)
+import dataclass.data
+
+@data class Cumulative(enabled: Boolean)

--- a/core/shared/src/main/scala/plotly/element/Error.scala
+++ b/core/shared/src/main/scala/plotly/element/Error.scala
@@ -1,12 +1,14 @@
 package plotly
 package element
 
+import dataclass.data
+
 import java.lang.{ Boolean => JBoolean, Double => JDouble }
 
 sealed abstract class Error(val `type`: String) extends Product with Serializable
 
 object Error {
-  case class Data(
+  @data class Data(
          array: Seq[Double],
        visible: Option[Boolean],
      symmetric: Option[Boolean],
@@ -28,7 +30,7 @@ object Error {
       )
   }
 
-  case class Percent(
+  @data class Percent(
     value: Double,
     visible: Option[Boolean],
     symmetric: Option[Boolean],
@@ -50,7 +52,7 @@ object Error {
       )
   }
 
-  case class Constant(
+  @data class Constant(
         value: Double,
         color: Option[String],
     thickness: Option[Double],

--- a/core/shared/src/main/scala/plotly/element/Line.scala
+++ b/core/shared/src/main/scala/plotly/element/Line.scala
@@ -1,9 +1,11 @@
 package plotly
 package element
 
+import dataclass.data
+
 import java.lang.{ Double => JDouble }
 
-final case class Line(
+@data class Line(
          shape: Option[LineShape],
          color: Option[OneOrSeq[Color]],
          width: Option[OneOrSeq[Double]],

--- a/core/shared/src/main/scala/plotly/element/LocalDateTime.scala
+++ b/core/shared/src/main/scala/plotly/element/LocalDateTime.scala
@@ -1,8 +1,10 @@
 package plotly.element
 
+import dataclass.data
+
 import scala.util.Try
 
-case class LocalDateTime(
+@data class LocalDateTime(
   year: Int,
   month: Int,
   dayOfMonth: Int,

--- a/core/shared/src/main/scala/plotly/element/Marker.scala
+++ b/core/shared/src/main/scala/plotly/element/Marker.scala
@@ -3,7 +3,9 @@ package element
 
 import java.lang.{ Double => JDouble }
 
-final case class Marker(
+import dataclass.data
+
+@data class Marker(
           size: Option[OneOrSeq[Int]],
          color: Option[OneOrSeq[Color]],
        opacity: Option[OneOrSeq[Double]],

--- a/core/shared/src/main/scala/plotly/element/ScatterMode.scala
+++ b/core/shared/src/main/scala/plotly/element/ScatterMode.scala
@@ -1,7 +1,9 @@
 package plotly
 package element
 
-case class ScatterMode(flags: Set[ScatterMode.Flag])
+import dataclass.data
+
+@data class ScatterMode(flags: Set[ScatterMode.Flag])
 
 object ScatterMode {
   def apply(flags: Flag*): ScatterMode =

--- a/core/shared/src/main/scala/plotly/element/Symbol.scala
+++ b/core/shared/src/main/scala/plotly/element/Symbol.scala
@@ -1,5 +1,6 @@
 package plotly
 package element
+import dataclass.data
 
 sealed abstract class Symbol(label0: String, idx0: Int) extends Product with Serializable {
   def idx: Int = idx0 + (if (open) 100 else 0)
@@ -14,10 +15,10 @@ object Symbol {
     def dot: Boolean
   }
 
-  case class  Circle(open: Boolean = false, dot: Boolean = false) extends DotSymbol("circle",  0)
-  case class  Square(open: Boolean = false, dot: Boolean = false) extends DotSymbol("square",  1)
-  case class Diamond(open: Boolean = false, dot: Boolean = false) extends DotSymbol("diamond", 2)
-  case class   Cross(open: Boolean = false, dot: Boolean = false) extends DotSymbol("cross",   3)
+  @data class  Circle(open: Boolean = false, dot: Boolean = false) extends DotSymbol("circle",  0)
+  @data class  Square(open: Boolean = false, dot: Boolean = false) extends DotSymbol("square",  1)
+  @data class Diamond(open: Boolean = false, dot: Boolean = false) extends DotSymbol("diamond", 2)
+  @data class   Cross(open: Boolean = false, dot: Boolean = false) extends DotSymbol("cross",   3)
 
   /*
   "4" | "x" | "104" | "x-open" | "204" | "x-dot" | "304" | "x-open-dot"

--- a/core/shared/src/main/scala/plotly/element/TextFont.scala
+++ b/core/shared/src/main/scala/plotly/element/TextFont.scala
@@ -1,4 +1,6 @@
 package plotly
 package element
 
-final case class TextFont(family: String)
+import dataclass.data
+
+@data class TextFont(family: String)

--- a/core/shared/src/main/scala/plotly/layout/Annotation.scala
+++ b/core/shared/src/main/scala/plotly/layout/Annotation.scala
@@ -3,9 +3,10 @@ package layout
 
 import java.lang.{ Boolean => JBoolean }
 
+import dataclass.data
 import plotly.element._
 
-final case class Annotation(
+@data class Annotation(
        xref: Option[Ref],
        yref: Option[Ref],
           x: Option[Element],

--- a/core/shared/src/main/scala/plotly/layout/Axis.scala
+++ b/core/shared/src/main/scala/plotly/layout/Axis.scala
@@ -3,9 +3,10 @@ package layout
 
 import java.lang.{ Integer => JInt, Double => JDouble, Boolean => JBoolean }
 
+import dataclass.data
 import plotly.element._
 
-final case class Axis(
+@data class Axis(
            title: Option[String],
        titlefont: Option[Font],
         showgrid: Option[Boolean],

--- a/core/shared/src/main/scala/plotly/layout/Font.scala
+++ b/core/shared/src/main/scala/plotly/layout/Font.scala
@@ -4,8 +4,9 @@ package layout
 import plotly.element._
 
 import java.lang.{ Integer => JInt }
+import dataclass.data
 
-final case class Font(
+@data class Font(
     size: Option[Int],
   family: Option[String],
    color: Option[Color]

--- a/core/shared/src/main/scala/plotly/layout/Layout.scala
+++ b/core/shared/src/main/scala/plotly/layout/Layout.scala
@@ -4,8 +4,9 @@ package layout
 import java.lang.{ Integer => JInt, Double => JDouble, Boolean => JBoolean }
 
 import plotly.element._
+import dataclass.data
 
-final case class Layout(
+@data class Layout(
           title: Option[String],
          legend: Option[Legend],
           width: Option[Int],

--- a/core/shared/src/main/scala/plotly/layout/Legend.scala
+++ b/core/shared/src/main/scala/plotly/layout/Legend.scala
@@ -4,8 +4,9 @@ package layout
 import java.lang.{ Double => JDouble }
 
 import plotly.element._
+import dataclass.data
 
-final case class Legend(
+@data class Legend(
             x: Option[Double],
             y: Option[Double],
    traceorder: Option[TraceOrder],

--- a/core/shared/src/main/scala/plotly/layout/Margin.scala
+++ b/core/shared/src/main/scala/plotly/layout/Margin.scala
@@ -2,8 +2,9 @@ package plotly
 package layout
 
 import java.lang.{ Integer => JInt, Boolean => JBoolean }
+import dataclass.data
 
-final case class Margin(
+@data class Margin(
   autoexpand: Option[Boolean],
            l: Option[Int],
            r: Option[Int],

--- a/demo/src/main/scala/plotly/demo/Demo.scala
+++ b/demo/src/main/scala/plotly/demo/Demo.scala
@@ -6,7 +6,7 @@ import plotly.Plotly
 
 import org.scalajs.dom
 
-import scalatags.JsDom.all._
+import scalatags.JsDom.all.{area => _, _}
 
 @JSExport object Demo {
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -9,6 +9,7 @@ object Deps {
 
   def almondScalaApi = "sh.almond" %% "jupyter-api" % "0.8.2"
   def argonautShapeless = setting("com.github.alexarchambault" %%% "argonaut-shapeless_6.2" % "1.2.0-M11")
+  def dataClass = "io.github.alexarchambault" %% "data-class" % "0.2.0"
   def jodaTime = "joda-time" % "joda-time" % "2.10.4"
   def rhino = "org.mozilla" % "rhino" % "1.7.11"
   def shapeless = setting("com.chuusai" %%% "shapeless" % "2.3.3")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -90,6 +90,11 @@ object Settings {
   private val scala212 = "2.12.10"
   private val scala213 = "2.13.1"
 
+  private lazy val isAtLeastScala213 = Def.setting {
+    import Ordering.Implicits._
+    CrossVersion.partialVersion(scalaVersion.value).exists(_ >= (2, 13))
+  }
+
   lazy val shared = Seq(
     crossScalaVersions := Seq(scala213, scala212),
     scalaVersion := scala213,
@@ -97,7 +102,15 @@ object Settings {
       "Webjars Bintray" at "https://dl.bintray.com/webjars/maven/",
       Resolver.sonatypeRepo("releases"),
       "jitpack" at "https://jitpack.io"
-    )
+    ),
+    libraryDependencies ++= {
+      if (isAtLeastScala213.value) Nil
+      else Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
+    },
+    scalacOptions ++= {
+      if (isAtLeastScala213.value) Seq("-Ymacro-annotations")
+      else Nil
+    }
   )
 
   lazy val dontPublish = Seq(


### PR DESCRIPTION
This adds convenient `with…` methods to all of the former case classes in particular. And should make it easier to preserve binary compatibility when adding fields to them.