### PR TITLE
fix scala.js example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,24 +68,20 @@ import plotly._, element._, layout._, Plotly._
 
 Then define plots like
 ```scala
-val x = 0.0 to 10.0 by 0.1
+val x = (0 to 100).map(_ * 0.1)
 val y1 = x.map(d => 2.0 * d + util.Random.nextGaussian())
 val y2 = x.map(math.exp)
 
 val plot = Seq(
-  Scatter(
-    x, y1, name = "Approx twice"
-  ),
-  Scatter(
-    x, y2, name = "Exp"
-  )
+  Scatter().withX(x).withY(y1).withName("Approx twice"),
+  Scatter().withX(x).withY(y2).withName("Exp")
 )
 ```
 and plot them with
+
 ```scala
-plot.plot(
-  title = "Curves"
-)
+val lay = Layout().withTitle("Curves")
+plot.plot("plot", lay)  // attaches to div element with id 'plot'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ val y1 = x.map(d => 2.0 * d + util.Random.nextGaussian())
 val y2 = x.map(math.exp)
 
 val plot = Seq(
-  Scatter().withX(x).withY(y1).withName("Approx twice"),
-  Scatter().withX(x).withY(y2).withName("Exp")
+  Scatter(x, y1).withName("Approx twice"),
+  Scatter(x, y2).withName("Exp")
 )
 ```
 and plot them with


### PR DESCRIPTION
Thanks for this library, only found it by searching after trying multiple others all of which had issues. This PR fixes the example code in the README to work with the latest version on Scala 2.13 and without deprecation warnings.