### PR TITLE
Add meta charset tag

### DIFF
--- a/render/jvm/src/main/scala/plotly/Plotly.scala
+++ b/render/jvm/src/main/scala/plotly/Plotly.scala
@@ -144,6 +144,7 @@ object Plotly {
       s"""<!DOCTYPE html>
          |<html>
          |<head>
+         |<meta charset="UTF-8">
          |<title>${layout.title.getOrElse("plotly chart")}</title>
          |$plotlyHeader
          |</head>


### PR DESCRIPTION
Hello.
```<meta charset="UTF-8">``` is necessary. Browsers cannot handle UTF-8 correctly without this.
