### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you're using [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), you 
 jupyter labextension install jupyterlab-plotly
 ```
 
-Also, you may have to install `plotlywidget` and `plotly-extension` with `--no-build` option and then build them if graph won't show up and you find a message `ReferenceError: require is not defined` in debug console in browser.
+Also, you may have to install plotlywidget and plotly-extension with `--no-build` option and then build them if graph won't show up and you find a message `ReferenceError: require is not defined` in debug console in browser.
 
 ```bash
 export NODE_OPTIONS=--max-old-space-size=4096

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ If you're using [JupyterLab](https://jupyterlab.readthedocs.io/en/stable/), you 
 jupyter labextension install jupyterlab-plotly
 ```
 
+Also, you may have to install `plotlywidget` and `plotly-extension` with `--no-build` option and then build them if graph won't show up and you find a message `ReferenceError: require is not defined` in debug console in browser.
+
+```bash
+export NODE_OPTIONS=--max-old-space-size=4096
+jupyter labextension install plotlywidget@0.8.0 --no-build
+jupyter labextension install @jupyterlab/plotly-extension@0.18.2 --no-build
+jupyter lab build
+unset NODE_OPTIONS
+```
+
+Reference is [here](https://github.com/plotly/plotly_express/issues/38)
+
 ### From scala-js
 
 Add the corresponding dependency to your project, like


### PR DESCRIPTION
Hi, I added some guides to fix an error when using plotly-scala in jupyterlab.

When I first tried to plot a demo graph in jupyterlab, no graph showed up and I found `ReferenceError: require is not defined` message in browser console.  I tried  the solution suggested [in this issue](https://github.com/plotly/plotly_express/issues/38), which successfully fixed my error.

Note: I am not sure this is an appropriate solution. Maybe other factors caused my error. If you think so, just ignore this PR.