### PR TITLE
Add missing wrapping of null to None, in Seq[Trace].plot()

### DIFF
--- a/almond/src/main/scala/plotly/Almond.scala
+++ b/almond/src/main/scala/plotly/Almond.scala
@@ -300,7 +300,7 @@ object Almond {
           .withEditable(Option(editable).map[Boolean](identity))
           .withResponsive(Option(responsive).map[Boolean](identity))
           .withShowEditInChartStudio(Option(showEditInChartStudio).map[Boolean](identity))
-          .withPlotlyServerURL(plotlyServerURL),
+          .withPlotlyServerURL(Option(plotlyServerURL)),
         div
       )
 


### PR DESCRIPTION
Otherwise null pointer exceptions by default.